### PR TITLE
[WIP] Update guide links

### DIFF
--- a/guides/peggo-relayer.md
+++ b/guides/peggo-relayer.md
@@ -4,5 +4,5 @@ Peggo is a Go implementation of the Peggy Orchestrator for the Injective Chain.
 
 Follow official guide to setup [peggo on testnet][peggo-testnet-link] or settup [peggo for mainnet][peggo-mainet-link].
 
-[peggo-mainnet-link]: https://chain.injective.network/guides/mainnet/peggo.html
-[peggo-testnet-link]: https://chain.injective.network/guides/testnet/peggo.html
+[peggo-mainnet-link]: https://docs.injective.network/guides/mainnet/peggo.html
+[peggo-testnet-link]: https://docs.injective.network/guides/testnet/peggo.html

--- a/guides/upgrade-node.md
+++ b/guides/upgrade-node.md
@@ -2,4 +2,4 @@
 
 Follow official guide to [upgrade your node][upgrade-doc-link]
 
-[upgrade-doc-link]: https://docs.injective.network/docs/staking/mainnet/validate-on-mainnet/upgrading-your-node
+[upgrade-doc-link]: https://docs.injective.network/guides/mainnet/canonical-chain-upgrade.html

--- a/guides/validator-node.md
+++ b/guides/validator-node.md
@@ -2,4 +2,4 @@
 
 To become a validator follow [official gude][validator-link]
 
-[validator-link]: https://chain.injective.network/guides/mainnet/becoming-a-validator.html
+[validator-link]: https://docs.injective.network/guides/mainnet/becoming-a-validator.html


### PR DESCRIPTION
- Changed the documentation subdomain from `chain` to `docs` for some of the guides.
- Updated subdirectory for some of the links.