### PR TITLE
feat: update mongo logging

### DIFF
--- a/docker/docker-compose.prod.yaml
+++ b/docker/docker-compose.prod.yaml
@@ -4,6 +4,8 @@ services:
 
   mongo:
     restart: always
+    logging:
+      driver: journald
 
   injective-core:
     restart: always


### PR DESCRIPTION
User experienced corrupted logs due to an ungrateful shutdown because of lack of resources. When using the JSON log parser, incomplete/corrupted logs will prevent the user from viewing future logs after the corrupted line. Hence, the switch to journals logging.

cc: @achilleas-kal 