### PR TITLE
Update links and guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Injective Chain releases
 
-The repository hosts Injective Chain releases of binary artifacts.
+This repository hosts Injective Chain releases of binary artifacts.
 
 It also contains hassle-free guides and scripts for getting started and managing Injective Chain nodes.
 
@@ -9,8 +9,10 @@ It also contains hassle-free guides and scripts for getting started and managing
 * [Injective Exchange Service Setup Guide](https://www.notion.so/Injective-Exchange-Service-Setup-Guide-7e59980634d54991862300670583d46a) (Includes Running a Node)
 * [Create a new node and join the network](guides/new-node.md)
 * [Sync node from the snapshot](guides/sync-node.md) (quickest way to sync blocks).
-* [Sync node from scratch via public sentries](guides/sync-node.md) (better decentralization factor).
 * [Upgrade Node to the latest version](guides/upgrade-node.md)
+
+# * [Sync node from scratch via public sentries](guides/sync-node.md) (better decentralization factor).
+
 
 ## Requirements
 
@@ -18,7 +20,7 @@ The following requirements are required to run the node natively.
 
 ### Hardware
 
-The following table shows the recommended hardware requirements for the running node on the mainnet.
+The following table shows the minimum recommended hardware requirements for the running node on the mainnet.
 
 | Validator Node   | Sentry Node    |
 | -----------------| ---------------|

--- a/guides/sync-node.md
+++ b/guides/sync-node.md
@@ -1,21 +1,9 @@
-# Sync From Our Snapshot
+# Sync From a Snapshot
 
-Sync from a snapshot is the easiest/quickest way to sync the injective node.
+Syncing from a snapshot is the easiest and quickest way to sync the injective node.
 
-Follow manual process [here.][sync-guide-link]
+Follow the process [here](https://docs.injective.network/nodes/RunNode/mainnet), or use a  [sync script](../scripts/README.md).
 
-Or use automation [sync script](../scripts/README.md)
+Daily archival snapshots are available on [ChainLayer/QuickSync](https://quicksync.io/networks/injective.html).
 
-Daily archival snapshots are available on [quicksync link](https://quicksync.io/networks/injective.html).
-
-**NOTE:**  You always have the option to sync your sentry from scratch via public sentries, which is a more decentralized approach.
-
-# Sync From Scratch 
-
-Due to breaking changes we made and [Canonical Chain Mainnet](https://blog.injectiveprotocol.com/injective-canonical-chain-mainnet-release/) release, you will need to sync using different binary versions.
-
-It's a seamless process, and [Official guide.](https://chain.injective.network/guides/mainnet/join-network.html) will help you join the network sync from scratch to Canonical Chain latest network block.
-
-
-[sync-guide-link]: https://docs.injective.network/docs/staking/mainnet/validate-on-mainnet/sync-from-snapshot/
-[using-systemd-guide-link]: https://chain.injective.network/guides/mainnet/join-network.html
+**NOTE:**  You always have the option to sync your sentry from scratch via public sentries, which is a more decentralized approach. However, the process is quite complex and involves running a node with multiple binaries (starting from the first Injective release) and upgrading at certain block heights.

--- a/guides/upgrade-node.md
+++ b/guides/upgrade-node.md
@@ -1,5 +1,12 @@
 # Upgrading your Injective Chain Node
 
-Follow official guide to [upgrade your node][upgrade-doc-link]
+To upgrade your node, follow these steps:
+1. Sync your node to the block height predetermined by the upgrade governance proposal.
+2. The node will automatically panic/stop at the predetermined upgrade height.
+3. Remove the old binaries and install the new release binaries.
+4. Restart the node.
 
-[upgrade-doc-link]: https://docs.injective.network/guides/mainnet/canonical-chain-upgrade.html
+See [here][release-versions] for the most recent and prior releases.
+
+[release-versions]: https://github.com/InjectiveLabs/injective-chain-releases/releases
+ 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,9 +1,9 @@
 # Scripts
-Those are set of scripts that will help you to bootstrap the Injective node or sync it with the network. 
+These scripts will help you to bootstrap the Injective node and sync it with the network. 
 
-**NOTE:**  If you are running scripts on an existing node, your configuration will be backed up before the sync process. Nevertheless, We highly recommend that you also do a manual backup of node configuration, keyring [following this step][backup-link].
+**NOTE:**  If you are running scripts on an existing node, your configuration will be backed up before the sync process. Nevertheless, we highly recommend that you also do a manual backup of your node configuration and keyring.
 
-##  Requirments
+##  Requirements
 * [Go Installed][go-install-link]
 * [Git Installed][git-link]
 * [AWS CLI][aws-cli-install-link] (only for snapshot sync, aws account not required)
@@ -31,7 +31,6 @@ cd scripts
 Wait until the sync process completes. It can take few hours, depending on your internet connection. If the process is interrupted and the script stops (server restart or any other reason), run it again. It will continue the sync process.
 
 
-[backup-link]: https://docs.injective.network/docs/staking/mainnet/validate-on-mainnet/sync-from-snapshot/#step-1-backup-node-credentials-keyring--clear-local-injectived-data
 [git-link]:https://github.com/git-guides/install-git
 [go-install-link]: https://golang.org/doc/install
 [aws-cli-install-link]: https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html


### PR DESCRIPTION
- Updated broken/old links, refreshed guides
- Removed/commented out syncing from scratch since link to guide is broken and process is likely too complex for anyone to use this method anymore.
- Added upgrade node guide