### PR TITLE
feat: configurable statsd agent

### DIFF
--- a/docker/.env.mainnet.example
+++ b/docker/.env.mainnet.example
@@ -50,8 +50,9 @@ INJ_CORE_STACK_RESOURCE_RAM_RESEVATION=30G
 INJ_CORE_CMD_STREAM_API="--chainstream-server 0.0.0.0:9999" #Set empty string to disable
 WASM_MEM_CACHE_SIZE=3000
 # Statsd
-INJ_STATSD_ENABLED="true"
+INJ_STATSD_ENABLED="false"
 INJ_STATSD_ADDRESS="host.docker.internal:8125"
+INJ_STATSD_AGENT="datadog"
 # Peggo Optional Env #
 INJ_ADDR=""
 INJ_PEGGO_STATSD_DISABLED="true"

--- a/docker/.env.testnet.example
+++ b/docker/.env.testnet.example
@@ -49,8 +49,9 @@ INJ_CORE_STACK_RESOURCE_RAM_RESEVATION=20G
 INJ_CORE_CMD_STREAM_API="--chainstream-server 0.0.0.0:9999" #Set empty string to disable
 WASM_MEM_CACHE_SIZE=3000
 # Statsd
-INJ_STATSD_ENABLED="true"
+INJ_STATSD_ENABLED="false"
 INJ_STATSD_ADDRESS="host.docker.internal:8125"
+INJ_STATSD_AGENT="datadog"
 # Peggo Optional Env #
 INJ_ADDR=""
 INJ_PEGGO_STATSD_DISABLED="true"

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -45,6 +45,7 @@ services:
         --rpc.laddr "tcp://0.0.0.0:26657" \
         --statsd-address=${INJ_STATSD_ADDRESS} \
         --statsd-enabled=${INJ_STATSD_ENABLED} \
+        --statsd-agent=${INJ_STATSD_AGENT} \
         ${INJ_CORE_CMD_STREAM_API} \
         --wasm.memory_cache_size ${WASM_MEM_CACHE_SIZE} \
         start


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Disabled Statsd by default in the configuration.
	- Set the default Statsd agent to Datadog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->