### PR TITLE
[INFRA-85] feat: pin provisioner image

### DIFF
--- a/docker/.env.mainnet.example
+++ b/docker/.env.mainnet.example
@@ -5,6 +5,8 @@
 ###############################
 ### Start User Configurable ###
 ###############################
+# Provisioner #
+UBUNTU_VERSION=jammy
 
 # Network Env #
 MONIKER=injective

--- a/docker/.env.testnet.example
+++ b/docker/.env.testnet.example
@@ -6,6 +6,9 @@
 ### Start User Configurable ###
 ###############################
 
+# Provisioner #
+UBUNTU_VERSION=jammy
+
 # Network Env #
 MONIKER=injective
 CHAIN_ID=injective-888

--- a/docker/addons/docker-compose.provisioner.yaml
+++ b/docker/addons/docker-compose.provisioner.yaml
@@ -2,7 +2,7 @@ version: '3.8'
 services:
   provisioner:
     container_name: injective-provisioner
-    image: ubuntu:latest
+    image: ubuntu:${UBUNTU_VERSION}
     command: [ "bash", "/home/ubuntu/scripts/provision-core.sh" ]
     environment:
       TZ: America/New_York


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new configuration parameter `UBUNTU_VERSION` set to `jammy` across various Docker environments to ensure consistent Ubuntu versioning in provisioning services.
- **Refactor**
	- Updated the Docker Compose file to utilize the `UBUNTU_VERSION` variable, replacing hardcoded Ubuntu image versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->