### PR TITLE
feat: remove personal namespace in json rpc api flag

### DIFF
--- a/docker/.env.testnet.example
+++ b/docker/.env.testnet.example
@@ -61,7 +61,7 @@ INJ_ADDR=""
 INJ_PEGGO_STATSD_DISABLED="true"
 INJ_PEGGO_STATSD_ADDR=""
 # EVM Specific Env #
-INJ_CORE_JSON_RPC_FLAGS='--json-rpc.address="0.0.0.0:8545" --json-rpc.ws-address="0.0.0.0:8546" --json-rpc.api="eth,web3,net,txpool,debug,personal,inj" --json-rpc.enable=true'
+INJ_CORE_JSON_RPC_FLAGS='--json-rpc.address="0.0.0.0:8545" --json-rpc.ws-address="0.0.0.0:8546" --json-rpc.api="eth,web3,net,txpool,debug,inj" --json-rpc.enable=true'
 
 # Provisioner Specific Env #
 GIT_TESTNET_TAG="v1.10-1677061209"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated environment configuration to remove the "personal" API from the list of enabled JSON-RPC APIs in testnet settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->