### PR TITLE
bump mongodb version

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -7,7 +7,7 @@ networks:
 services:
   mongo:
     container_name: mongo
-    image: mongo:5.0.5
+    image: mongo:6.0.7
     restart: always
     command: mongod --dbpath /data/db --replSet rs0 --port 27017 --bind_ip 0.0.0.0 --wiredTigerCacheSizeGB ${MONGO_WIREDTIGER_CACHE_GB}
     ports:


### PR DESCRIPTION
BM nodes are already running mongo v6.0.7, adding the compose update for parity. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the MongoDB version used in the Docker Compose setup to a newer release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->