### PR TITLE
enable prometheus

### DIFF
--- a/docker/.env.mainnet.example
+++ b/docker/.env.mainnet.example
@@ -45,7 +45,7 @@ LOG_BUGSNAG_ENABLED=false
 
 # Injective Core env #
 # Optional
-INJ_CORE_IMAGE_VERSION=v1.16.0-watchdog
+INJ_CORE_IMAGE_VERSION=v1.16.2
 # Resource limits works only with swarm mode
 INJ_CORE_STACK_RESOURCE_RAM_LIMIT=80G
 INJ_CORE_STACK_RESOURCE_RAM_RESEVATION=30G

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -67,6 +67,7 @@ services:
       ${INJ_CORE_JSON_RPC_FLAGS} \
       start
     ports:
+    - 26660:26660
     - 26656:26656
     - 26657:26657
     - 9900:9900


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Exposed an additional service port (26660) for external access. Ensure your network/firewall settings allow this port if you intend to use it.

- Chores
  - Updated the mainnet core component image version to v1.16.2 to align with the latest release. Existing configurations remain unchanged aside from the version bump.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->